### PR TITLE
Fixed js and perl plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 akulai/akulai-plugins
 
 # Ignore the VOSK model folder
-akulai/model/vosk-model
+akulai/model
 
 # Ignore the plugins directory
 akulai/plugins
@@ -28,6 +28,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+bin/
 lib/
 lib64/
 parts/
@@ -141,6 +142,10 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+# Ignore venv files
+/bin
+/lib64
+/pyvenv.cfg
 
 # Spyder project settings
 .spyderproject

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,4 @@ pyttsx3
 vosk
 pyaudio
 js2py
-json
+pypi-json


### PR DESCRIPTION
The js and perl plugins now work using subprocess to run them using node or perl. Command is passed in as a command line parameter, and output is from STDOUT - console.log(output) for NodeJS and print output; for perl.

js and perl plugins need to be re-written to use argument passing and stdout.